### PR TITLE
feat: add private base layer and Xcode CLI tools to init

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,16 +128,24 @@ loadout display solo         # force laptop-solo mode
 
 ### Dotfile Merge Strategies
 
-Loadout merges `~/.dotfiles/dotfiles/base/` (public) with
-`~/.dotfiles-private/dotfiles/orgs/<org>/` (private) using per-file strategies:
+Loadout merges three layers of configuration using per-file strategies:
+
+| Layer | Source | Priority |
+|-------|--------|----------|
+| Public base | `~/.dotfiles/dotfiles/base/` | Lowest |
+| Private base | `~/.dotfiles-private/dotfiles/base/` | Middle (optional) |
+| Org overlays | `~/.dotfiles-private/dotfiles/orgs/<org>/` | Highest (last org wins) |
+
+The private base layer is for personal private config that applies across all
+orgs. When the directory does not exist, the pipeline uses two layers as before.
 
 | File type | Strategy | Behavior |
 |-----------|----------|----------|
-| `.zshrc`, `.aliases`, `.zprofile`, `.zshenv` | Concatenation | Base + org appended with separator |
-| `.gitconfig` | Include | Git native `[include]` directives to `~/.gitconfig.d/<org>` |
-| `*.json` | Deep merge | Recursive merge, org wins on conflict |
-| `*.yaml`, `*.yml` | Deep merge | Recursive merge, org wins on conflict |
-| Everything else | Replace | Org file replaces base entirely |
+| `.zshrc`, `.aliases`, `.zprofile`, `.zshenv` | Concatenation | Layers appended with separators |
+| `.gitconfig` | Include | Git native `[include]` directives to `~/.gitconfig.d/` |
+| `*.json` | Deep merge | Recursive merge, later layers win on conflict |
+| `*.yaml`, `*.yml` | Deep merge | Recursive merge, later layers win on conflict |
+| Everything else | Replace | Later layer replaces earlier entirely |
 
 Output is staged to `~/.dotfiles/build/` (via atomic temp-dir swap) then copied to `~/`.
 Existing files are backed up to `~/.dotfiles/backups/` before overwriting.
@@ -171,13 +179,24 @@ Idempotent — safe to re-run.
     └── defaults-laptop-*.sh
 
 ~/.dotfiles-private/                # oakensoul/dotfiles-private
-├── brewfiles/orgs/
-│   └── Brewfile.<org>              # per-org Homebrew packages
-├── dotfiles/orgs/<org>/
-│   ├── .zshrc, .gitconfig          # per-org dotfile overlays
-├── globals/orgs/
-│   └── globals.<org>.sh            # per-org env vars (sourced, not executed)
+├── brewfiles/
+│   ├── Brewfile.private            # private base Homebrew packages (optional)
+│   └── orgs/
+│       └── Brewfile.<org>          # per-org Homebrew packages
+├── dotfiles/
+│   ├── base/                       # private base dotfiles (optional)
+│   │   ├── .zshrc, .gitconfig      # private defaults for all orgs
+│   │   └── npm-globals.txt         # private base npm packages
+│   └── orgs/<org>/
+│       ├── .zshrc, .gitconfig      # per-org dotfile overlays
+├── globals/
+│   ├── globals.private.sh          # private base globals script (optional)
+│   └── orgs/
+│       └── globals.<org>.sh        # per-org env vars (sourced, not executed)
 └── claude/
+    ├── base/                       # private base Claude config (optional)
+    │   ├── mcp-private.json        # private base MCP config
+    │   └── CLAUDE.md               # private base CLAUDE.md overlay
     ├── orgs/<org>/
     │   ├── mcp-<org>.json          # per-org MCP config
     │   └── CLAUDE.md               # per-org CLAUDE.md overlay
@@ -191,7 +210,8 @@ Loadout assembles Brewfiles from fragments before running `brew bundle`:
 
 | Source | Path | Included |
 |--------|------|----------|
-| Base | `~/.dotfiles/brewfiles/Brewfile.base` | Always |
+| Public base | `~/.dotfiles/brewfiles/Brewfile.base` | Always |
+| Private base | `~/.dotfiles-private/brewfiles/Brewfile.private` | If present |
 | Per-org | `~/.dotfiles-private/brewfiles/orgs/Brewfile.<org>` | For each configured org |
 
 Fragments are concatenated into a single temp file and passed to
@@ -204,10 +224,12 @@ Loadout assembles Claude Code config from both repos into `~/.claude/`:
 
 | Source | Target | Strategy |
 |--------|--------|----------|
-| `claude/base/mcp-shared.json` + `claude/orgs/<org>/mcp-<org>.json` | `~/.claude/mcp.json` | Deep merge (org wins on conflict) |
-| `claude/CLAUDE.md.template` + `claude/orgs/<org>/CLAUDE.md` | `~/.claude/CLAUDE.md` | Concatenation with separators |
+| `claude/base/mcp-shared.json` + `claude/base/mcp-private.json` + `claude/orgs/<org>/mcp-<org>.json` | `~/.claude/mcp.json` | Deep merge (later layers win) |
+| `claude/CLAUDE.md.template` + `claude/base/CLAUDE.md` + `claude/orgs/<org>/CLAUDE.md` | `~/.claude/CLAUDE.md` | Concatenation with separators |
 | `claude/statusline.sh` | `~/.claude/statusline.sh` | Copy |
 | `claude/providers/*.sh` | `~/.claude/providers/` | Copy |
+
+The private base Claude config (`claude/base/` in dotfiles-private) is optional.
 
 ### macOS Defaults
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -101,15 +101,19 @@ Everything in `update` plus `brew upgrade` — run intentionally, can break thin
 
 ### `loadout build`
 
-Merges `~/.dotfiles/dotfiles/base/` + `~/.dotfiles-private/dotfiles/orgs/<org>/` fragments:
+Merges three layers of dotfile configuration:
+
+1. **Public base** — `~/.dotfiles/dotfiles/base/` (lowest priority)
+2. **Private base** — `~/.dotfiles-private/dotfiles/base/` (middle priority, optional)
+3. **Org overlays** — `~/.dotfiles-private/dotfiles/orgs/<org>/` (highest priority)
 
 | File type | Strategy |
 |-----------|----------|
-| `.zshrc`, `.aliases` | Concatenation — base + org fragment |
+| `.zshrc`, `.aliases` | Concatenation — layers appended with separators |
 | `.gitconfig` | Native `[include]` — git handles merge |
-| JSON | Deep merge, org wins on conflict |
-| YAML | Deep merge, org wins on conflict |
-| Unknown | Org replaces base |
+| JSON | Deep merge, later layers win on conflict |
+| YAML | Deep merge, later layers win on conflict |
+| Unknown | Later layer replaces earlier |
 
 Output staged to `~/.dotfiles/build/` via an atomic temp-dir-then-swap pattern, then copied to `~/`. Existing files are backed up to `~/.dotfiles/backups/` with UTC timestamps before overwriting. Idempotent — safe to re-run.
 
@@ -143,24 +147,28 @@ Future checks (planned): devbox reachability, canvas staleness, AWS credential e
 
 ## Dotfile Build System
 
-Stow is replaced by a Python build step. No symlinks — orgs layer cleanly on top of base.
+Stow is replaced by a Python build step. No symlinks — layers merge cleanly.
 
 ```
-~/.dotfiles/dotfiles/base/     +    ~/.dotfiles-private/dotfiles/orgs/splash/
-        .zshrc                                   .zshrc
-        .gitconfig                               .gitconfig
-             │                                       │
-             └──────────── loadout build ────────────┘
-                                  │
-                        ~/.dotfiles/build/     ← staged output
-                                  │
-                              copy to ~/       ← written to final locations
+~/.dotfiles/dotfiles/base/   +   ~/.dotfiles-private/dotfiles/base/   +   ~/.dotfiles-private/dotfiles/orgs/splash/
+       .zshrc                            .zshrc                                     .zshrc
+       .gitconfig                        .gitconfig                                 .gitconfig
+            │                                │                                          │
+            └──── public base ───────────────┴──── private base ────────────────────────┘
+                                                        │
+                                              ~/.dotfiles/build/     ← staged output
+                                                        │
+                                                    copy to ~/       ← written to final locations
 ```
+
+The private base layer is optional — when `~/.dotfiles-private/dotfiles/base/` does not exist, the pipeline falls back to the two-layer model (public base + org overlays).
 
 `.gitconfig` uses git's native `[include]` mechanism — no merge logic needed:
 
 ```ini
 # base .gitconfig (built output)
+[include]
+    path = ~/.gitconfig.d/private-base
 [include]
     path = ~/.gitconfig.d/splash
 ```

--- a/loadout/brew.py
+++ b/loadout/brew.py
@@ -18,6 +18,7 @@ def _assemble_brewfile(config: LoadoutConfig) -> list[Path]:
 
     Looks for:
     - ``{dotfiles_dir}/brewfiles/Brewfile.base`` (always included if present)
+    - ``{dotfiles_private_dir}/brewfiles/Brewfile.private`` (private base, if present)
     - ``{dotfiles_private_dir}/brewfiles/orgs/Brewfile.{org}`` for each org
 
     Missing files are silently skipped.
@@ -30,6 +31,10 @@ def _assemble_brewfile(config: LoadoutConfig) -> list[Path]:
     base = config.dotfiles_dir / "brewfiles" / "Brewfile.base"
     if base.exists():
         fragments.append(base)
+
+    private_base = config.dotfiles_private_dir / "brewfiles" / "Brewfile.private"
+    if private_base.exists():
+        fragments.append(private_base)
 
     for org in config.orgs:
         org_file = config.dotfiles_private_dir / "brewfiles" / "orgs" / f"Brewfile.{org}"

--- a/loadout/build.py
+++ b/loadout/build.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # Copyright (C) 2025 Robert Gunnar Johnson Jr.
-"""Dotfile merge engine — build final dotfiles from base + org layers."""
+"""Dotfile merge engine — build final dotfiles from public base, private base, and org layers."""
 
 from __future__ import annotations
 
@@ -46,18 +46,18 @@ def _get_merge_strategy(filename: str) -> MergeStrategy:
     return MergeStrategy.REPLACE
 
 
-def _merge_concat(base_path: Path, org_path: Path, dest_path: Path) -> None:
-    """Merge by concatenating org content after base content with a separator.
+def _merge_concat(base_path: Path, overlay_path: Path, dest_path: Path, label: str) -> None:
+    """Merge by concatenating overlay content after base content with a separator.
 
-    When multiple orgs are configured, concatenation is intentionally cumulative:
-    each org's content is appended after the previous result so that all layers
+    When multiple layers are configured, concatenation is intentionally cumulative:
+    each layer's content is appended after the previous result so that all layers
     contribute to the final file.
     """
     base_content = base_path.read_text(encoding="utf-8") if base_path.exists() else ""
-    org_content = org_path.read_text(encoding="utf-8")
+    overlay_content = overlay_path.read_text(encoding="utf-8")
 
-    separator = f"\n# --- org overlay: {org_path.parent.name} ---\n"
-    merged = base_content.rstrip("\n") + separator + org_content
+    separator = f"\n# --- overlay: {label} ---\n"
+    merged = base_content.rstrip("\n") + separator + overlay_content
     dest_path.write_text(merged, encoding="utf-8")
 
 
@@ -153,12 +153,58 @@ def _backup_file(dest: Path, backup_dir: Path) -> None:
     verbose_line(f"backed up {dest.name} → {backup_path}")
 
 
+def _apply_overlay(
+    build_dir: Path,
+    overlay_dir: Path,
+    label: str,
+    gitconfig_paths: dict[str, Path],
+) -> None:
+    """Apply a single overlay directory onto *build_dir* using merge strategies.
+
+    Files in *overlay_dir* are merged into *build_dir* according to each file's
+    merge strategy.  The *label* is used in status output and concat separators.
+    Gitconfig files are accumulated into *gitconfig_paths* for deferred handling.
+    """
+    if not overlay_dir.exists():
+        return
+
+    for overlay_file in sorted(overlay_dir.iterdir()):
+        if overlay_file.is_symlink():
+            verbose_line(f"skipping symlink in {label}: {overlay_file.name}")
+            continue
+        if not overlay_file.is_file():
+            continue
+
+        strategy = _get_merge_strategy(overlay_file.name)
+        dest = build_dir / overlay_file.name
+
+        if strategy is MergeStrategy.CONCAT:
+            _merge_concat(dest, overlay_file, dest, label)
+            status_line(">>", f"concat ({label})", overlay_file.name)
+
+        elif strategy is MergeStrategy.GITCONFIG:
+            gitconfig_paths[label] = overlay_file
+
+        elif strategy is MergeStrategy.JSON:
+            _merge_json(dest, overlay_file, dest)
+            status_line(">>", f"json ({label})", overlay_file.name)
+
+        elif strategy is MergeStrategy.YAML:
+            _merge_yaml(dest, overlay_file, dest)
+            status_line(">>", f"yaml ({label})", overlay_file.name)
+
+        elif strategy is MergeStrategy.REPLACE:
+            shutil.copy2(overlay_file, dest)
+            status_line(">>", f"replace ({label})", overlay_file.name)
+
+
 def _build_into(
     build_dir: Path,
     base_dir: Path,
     private_dir: Path,
     home_dir: Path,
     orgs: list[str],
+    private_base_dir: Path | None = None,
 ) -> None:
     """Run the merge pipeline into *build_dir* (Steps 1–3).
 
@@ -169,7 +215,7 @@ def _build_into(
         shutil.rmtree(build_dir)
     build_dir.mkdir(parents=True, exist_ok=True)
 
-    # Step 2: Copy base files into build_dir (skip symlinks).
+    # Step 2: Copy public base files into build_dir (skip symlinks).
     if base_dir.exists():
         for src in sorted(base_dir.iterdir()):
             if src.is_symlink():
@@ -179,52 +225,23 @@ def _build_into(
                 shutil.copy2(src, build_dir / src.name)
                 status_line(">>", "base", src.name)
 
-    # Step 3: Apply org overlays.
-    gitconfig_org_paths: dict[str, Path] = {}
+    gitconfig_paths: dict[str, Path] = {}
 
+    # Step 2.5: Apply private base overlay.
+    if private_base_dir is not None:
+        _apply_overlay(build_dir, private_base_dir, "private-base", gitconfig_paths)
+
+    # Step 3: Apply org overlays.
     for org in orgs:
         org_dir = private_dir / org
-        if not org_dir.exists():
-            continue
+        _apply_overlay(build_dir, org_dir, org, gitconfig_paths)
 
-        for org_file in sorted(org_dir.iterdir()):
-            if org_file.is_symlink():
-                verbose_line(f"skipping symlink in org {org}: {org_file.name}")
-                continue
-            if not org_file.is_file():
-                continue
-
-            strategy = _get_merge_strategy(org_file.name)
-            dest = build_dir / org_file.name
-
-            if strategy is MergeStrategy.CONCAT:
-                accumulated = build_dir / org_file.name
-                _merge_concat(accumulated, org_file, dest)
-                status_line(">>", f"concat ({org})", org_file.name)
-
-            elif strategy is MergeStrategy.GITCONFIG:
-                gitconfig_org_paths[org] = org_file
-
-            elif strategy is MergeStrategy.JSON:
-                accumulated = build_dir / org_file.name
-                _merge_json(accumulated, org_file, dest)
-                status_line(">>", f"json ({org})", org_file.name)
-
-            elif strategy is MergeStrategy.YAML:
-                accumulated = build_dir / org_file.name
-                _merge_yaml(accumulated, org_file, dest)
-                status_line(">>", f"yaml ({org})", org_file.name)
-
-            elif strategy is MergeStrategy.REPLACE:
-                shutil.copy2(org_file, dest)
-                status_line(">>", f"replace ({org})", org_file.name)
-
-    # Handle gitconfig after collecting all org paths.
-    if gitconfig_org_paths:
+    # Handle gitconfig after collecting all overlay paths.
+    if gitconfig_paths:
         base_gitconfig = build_dir / ".gitconfig"
         _merge_gitconfig(
             base_gitconfig if base_gitconfig.exists() else base_dir / ".gitconfig",
-            gitconfig_org_paths,
+            gitconfig_paths,
             build_dir / ".gitconfig",
             home_dir,
         )
@@ -242,6 +259,7 @@ def build_dotfiles(config: LoadoutConfig, *, dry_run: bool = False) -> None:
     home_dir = config.home
     build_dir = config.build_dir
     base_dir = config.dotfiles_dir / "dotfiles" / "base"
+    private_base_dir = config.dotfiles_private_dir / "dotfiles" / "base"
     private_dir = config.dotfiles_private_dir / "dotfiles" / "orgs"
     backup_dir = config.dotfiles_dir / "backups"
 
@@ -254,7 +272,7 @@ def build_dotfiles(config: LoadoutConfig, *, dry_run: bool = False) -> None:
     # Build into a temp directory first for atomic swap.
     tmp_build = Path(tempfile.mkdtemp(prefix="loadout-build-", dir=config.dotfiles_dir))
     try:
-        _build_into(tmp_build, base_dir, private_dir, home_dir, config.orgs)
+        _build_into(tmp_build, base_dir, private_dir, home_dir, config.orgs, private_base_dir)
 
         # Atomic swap: replace build_dir with the temp dir.
         if build_dir.exists():

--- a/loadout/check.py
+++ b/loadout/check.py
@@ -157,6 +157,16 @@ def check_brewfile_fragments(config: LoadoutConfig) -> list[CheckResult]:
                 )
             )
 
+        private_base = config.dotfiles_private_dir / "brewfiles" / "Brewfile.private"
+        if private_base.exists():
+            results.append(
+                CheckResult(
+                    status=CheckStatus.OK,
+                    label="Brewfile.private",
+                    detail=f"found at {private_base}",
+                )
+            )
+
         for org in config.orgs:
             org_brewfile = config.dotfiles_private_dir / "brewfiles" / "orgs" / f"Brewfile.{org}"
             if org_brewfile.exists():
@@ -212,6 +222,16 @@ def check_globals_scripts(config: LoadoutConfig) -> list[CheckResult]:
                 status=CheckStatus.WARN,
                 label="globals.base.sh",
                 detail=f"not found at {base_script}",
+            )
+        )
+
+    private_base_script = config.dotfiles_private_dir / "globals" / "globals.private.sh"
+    if private_base_script.exists():
+        results.append(
+            CheckResult(
+                status=CheckStatus.OK,
+                label="globals.private.sh",
+                detail=f"found at {private_base_script}",
             )
         )
 

--- a/loadout/claude.py
+++ b/loadout/claude.py
@@ -25,6 +25,15 @@ def _build_mcp_json(config: LoadoutConfig, *, dry_run: bool = False) -> None:
     except json.JSONDecodeError as exc:
         raise LoadoutBuildError(f"Malformed JSON in {base_path}: {exc}") from exc
 
+    private_base_mcp = config.dotfiles_private_dir / "claude" / "base" / "mcp-private.json"
+    if private_base_mcp.exists():
+        try:
+            pb_data: object = json.loads(private_base_mcp.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise LoadoutBuildError(f"Malformed JSON in {private_base_mcp}: {exc}") from exc
+        merged = deep_merge(merged, pb_data)
+        verbose_line("merged MCP config for private base")
+
     for org in config.orgs:
         org_mcp = config.dotfiles_private_dir / "claude" / "orgs" / org / f"mcp-{org}.json"
         if org_mcp.exists():
@@ -54,10 +63,16 @@ def _build_claude_md(config: LoadoutConfig, *, dry_run: bool = False) -> None:
 
     content = template_path.read_text(encoding="utf-8")
 
+    private_base_md = config.dotfiles_private_dir / "claude" / "base" / "CLAUDE.md"
+    if private_base_md.exists():
+        separator = "\n\n# --- overlay: private-base ---\n\n"
+        content = content.rstrip("\n") + separator + private_base_md.read_text(encoding="utf-8")
+        verbose_line("appended CLAUDE.md overlay for private base")
+
     for org in config.orgs:
         org_md = config.dotfiles_private_dir / "claude" / "orgs" / org / "CLAUDE.md"
         if org_md.exists():
-            separator = f"\n\n# --- org overlay: {org} ---\n\n"
+            separator = f"\n\n# --- overlay: {org} ---\n\n"
             content = content.rstrip("\n") + separator + org_md.read_text(encoding="utf-8")
             verbose_line(f"appended CLAUDE.md overlay for org: {org}")
 

--- a/loadout/globals.py
+++ b/loadout/globals.py
@@ -101,11 +101,10 @@ def install_pip_globals(packages: list[str], *, dry_run: bool = False) -> None:
         run(["pip", "install", "--user", package], dry_run=dry_run)
 
 
-def _run_base_globals_script(config: LoadoutConfig, *, dry_run: bool = False) -> None:
-    """Run the public base globals shell script if it exists."""
-    script = config.dotfiles_dir / "globals" / "globals.base.sh"
+def _run_globals_script(script: Path, *, dry_run: bool = False) -> None:
+    """Run a globals shell script if it exists."""
     if not script.exists():
-        verbose_line(f"Base globals script not found: {script}")
+        verbose_line(f"Globals script not found: {script}")
         return
     run(["bash", "-euo", "pipefail", str(script)], dry_run=dry_run)
 
@@ -148,16 +147,29 @@ def install_globals(config: LoadoutConfig, *, dry_run: bool = False) -> None:
 
     run_step(
         "Run base globals script",
-        lambda: _run_base_globals_script(config, dry_run=dry_run),
+        lambda: _run_globals_script(
+            config.dotfiles_dir / "globals" / "globals.base.sh", dry_run=dry_run
+        ),
+    )
+    run_step(
+        "Run private base globals script",
+        lambda: _run_globals_script(
+            config.dotfiles_private_dir / "globals" / "globals.private.sh",
+            dry_run=dry_run,
+        ),
     )
     run_step(
         "Install org globals scripts",
         lambda: _install_org_globals_scripts(config, dry_run=dry_run),
     )
 
-    # Collect npm and pip packages from org config files
+    # Collect npm and pip packages from private base and org config files
     npm_packages: list[str] = []
     pip_packages: list[str] = []
+
+    private_base_dir = config.dotfiles_private_dir / "dotfiles" / "base"
+    npm_packages.extend(_read_package_list(private_base_dir / "npm-globals.txt"))
+    pip_packages.extend(_read_package_list(private_base_dir / "pip-globals.txt"))
 
     for org in config.orgs:
         org_dir = config.dotfiles_private_dir / "dotfiles" / "orgs" / org

--- a/loadout/init.py
+++ b/loadout/init.py
@@ -19,6 +19,43 @@ from loadout.globals import install_globals
 from loadout.macos import apply_macos_defaults
 
 
+def _ensure_xcode_cli_tools(*, dry_run: bool = False) -> None:
+    """Ensure Xcode Command Line Tools are installed (macOS only).
+
+    On a fresh Mac, git and other developer tools require the CLI tools.
+    Checks via ``xcode-select -p``; if missing, triggers the install and
+    waits for completion.
+    """
+    if not is_macos():
+        ui.status_line("[dim]\u23ed[/dim]", "Xcode CLI Tools", "skipped (not macOS)")
+        return
+
+    result = runner.run(["xcode-select", "-p"], capture=True, check=False)
+    if result.returncode == 0:
+        ui.status_line("[green]\u2713[/green]", "Xcode CLI Tools", "already installed")
+        return
+
+    if dry_run:
+        ui.status_line("[dim]\u25b6[/dim]", "Xcode CLI Tools", "would install (dry run)")
+        return
+
+    # xcode-select --install opens a GUI dialog; the touch-file trick
+    # allows a headless install via softwareupdate instead.
+    runner.run(
+        [
+            "bash",
+            "-euo",
+            "pipefail",
+            "-c",
+            "touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress && "
+            'PROD=$(softwareupdate -l 2>&1 | grep -B 1 "Command Line Tools" '
+            '| grep -o "Command Line Tools.*" | head -1) && '
+            'softwareupdate -i "$PROD" --verbose && '
+            "rm -f /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress",
+        ],
+    )
+
+
 def _clone_repo(
     url: str,
     dest: Path,
@@ -159,7 +196,7 @@ def run_init(
 ) -> None:
     """Execute the full machine bootstrap flow.
 
-    This is the 11-step init sequence that sets up a new machine from scratch.
+    This is the 12-step init sequence that sets up a new machine from scratch.
     Steps are fail-fast: if any step raises, subsequent steps are skipped.
     Platform-conditional steps (macOS defaults, launch agent) are no-ops on
     non-macOS platforms.
@@ -171,7 +208,13 @@ def run_init(
 
     ui.section_header("Machine Bootstrap")
 
-    # 1. Clone dotfiles repos
+    # 1. Ensure Xcode CLI Tools (macOS — needed for git, brew, etc.)
+    ui.run_step(
+        "Ensure Xcode CLI Tools",
+        lambda: _ensure_xcode_cli_tools(dry_run=dry_run),
+    )
+
+    # 2. Clone dotfiles repos
     def _clone_repos() -> None:
         _clone_repo(
             f"https://github.com/{user}/dotfiles.git",
@@ -186,13 +229,13 @@ def run_init(
 
     ui.run_step("Clone dotfiles repos", _clone_repos)
 
-    # 2. Generate SSH key
+    # 3. Generate SSH key
     ui.run_step(
         "Generate SSH key",
         lambda: _generate_ssh_key(user, ssh_key_path, dry_run=dry_run),
     )
 
-    # 3. Register SSH key with GitHub
+    # 4. Register SSH key with GitHub
     ui.run_step(
         "Register SSH key with GitHub",
         lambda: _register_ssh_key_with_github(
@@ -202,7 +245,7 @@ def run_init(
         ),
     )
 
-    # 4. Switch remotes to SSH
+    # 5. Switch remotes to SSH
     ui.run_step(
         "Switch remotes to SSH",
         lambda: _switch_remotes_to_ssh(
@@ -212,43 +255,43 @@ def run_init(
         ),
     )
 
-    # 5. Build dotfiles
+    # 6. Build dotfiles
     ui.run_step(
         "Build dotfiles",
         lambda: build_dotfiles(config, dry_run=dry_run),
     )
 
-    # 6. Brew bundle
+    # 7. Brew bundle
     ui.run_step(
         "Brew bundle",
         lambda: brew_bundle(config, dry_run=dry_run),
     )
 
-    # 7. Install globals
+    # 8. Install globals
     ui.run_step(
         "Install globals",
         lambda: install_globals(config, dry_run=dry_run),
     )
 
-    # 8. Build Claude config
+    # 9. Build Claude config
     ui.run_step(
         "Build Claude config",
         lambda: build_claude_config(config, dry_run=dry_run),
     )
 
-    # 9. Apply macOS defaults
+    # 10. Apply macOS defaults
     ui.run_step(
         "Apply macOS defaults",
         lambda: apply_macos_defaults(config, dry_run=dry_run),
     )
 
-    # 10. Set up display launch agent
+    # 11. Set up display launch agent
     ui.run_step(
         "Set up display launch agent",
         lambda: _setup_launch_agent(config, dry_run=dry_run),
     )
 
-    # 11. Save config
+    # 12. Save config
     if not dry_run:
         ui.run_step(
             "Save config",

--- a/tests/fixtures/dotfiles-private/dotfiles/base/.aliases
+++ b/tests/fixtures/dotfiles-private/dotfiles/base/.aliases
@@ -1,0 +1,1 @@
+alias priv="private-command"

--- a/tests/fixtures/dotfiles-private/dotfiles/base/.gitconfig
+++ b/tests/fixtures/dotfiles-private/dotfiles/base/.gitconfig
@@ -1,0 +1,2 @@
+[core]
+    editor = nano

--- a/tests/fixtures/dotfiles-private/dotfiles/base/.vimrc
+++ b/tests/fixtures/dotfiles-private/dotfiles/base/.vimrc
@@ -1,0 +1,1 @@
+set tabstop=3

--- a/tests/fixtures/dotfiles-private/dotfiles/base/.zshrc
+++ b/tests/fixtures/dotfiles-private/dotfiles/base/.zshrc
@@ -1,0 +1,1 @@
+export PRIVATE_BASE_VAR=1

--- a/tests/fixtures/dotfiles-private/dotfiles/base/config.yaml
+++ b/tests/fixtures/dotfiles-private/dotfiles/base/config.yaml
@@ -1,0 +1,2 @@
+opts:
+  pager: "bat-private"

--- a/tests/fixtures/dotfiles-private/dotfiles/base/settings.json
+++ b/tests/fixtures/dotfiles-private/dotfiles/base/settings.json
@@ -1,0 +1,4 @@
+{
+  "theme": "private-dark",
+  "private_flag": true
+}

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -78,12 +78,12 @@ class TestMergeConcat:
         dest = tmp_path / "dest" / ".zshrc"
         dest.parent.mkdir()
 
-        _merge_concat(base, org, dest)
+        _merge_concat(base, org, dest, "test-org")
 
         content = dest.read_text(encoding="utf-8")
         assert "# base config" in content
         assert "export FOO=1" in content
-        assert "# --- org overlay: org ---" in content
+        assert "# --- overlay: test-org ---" in content
         assert "export BAR=2" in content
 
     def test_concat_without_base(self, tmp_path: Path) -> None:
@@ -96,7 +96,7 @@ class TestMergeConcat:
         dest = tmp_path / "dest" / ".zshrc"
         dest.parent.mkdir()
 
-        _merge_concat(base, org, dest)
+        _merge_concat(base, org, dest, "test-org")
 
         content = dest.read_text(encoding="utf-8")
         assert "export BAR=2" in content
@@ -315,7 +315,7 @@ class TestBuildDotfiles:
         zshrc = (tmp_path / ".zshrc").read_text(encoding="utf-8")
         assert "# base zshrc" in zshrc
         assert "# acme zshrc" in zshrc
-        assert "# --- org overlay:" in zshrc
+        assert "# --- overlay:" in zshrc
 
         # Verify gitconfig includes.
         gitconfig = (tmp_path / ".gitconfig").read_text(encoding="utf-8")
@@ -359,7 +359,7 @@ class TestBuildDotfiles:
         assert (tmp_path / ".zshrc").exists()
         zshrc = (tmp_path / ".zshrc").read_text(encoding="utf-8")
         assert "# base zshrc" in zshrc
-        assert "org overlay" not in zshrc
+        assert "# --- overlay:" not in zshrc
 
     def test_build_multiple_orgs(self, tmp_path: Path) -> None:
         config = _setup_dotfiles(tmp_path, ["alpha", "beta"])

--- a/tests/test_claude.py
+++ b/tests/test_claude.py
@@ -95,9 +95,9 @@ class TestBuildClaudeMd:
         content = (config.claude_dir / "CLAUDE.md").read_text(encoding="utf-8")
         assert "# Base Config" in content
         assert "Base content." in content
-        assert "# --- org overlay: acme ---" in content
+        assert "# --- overlay: acme ---" in content
         assert "Acme-specific rules." in content
-        assert "# --- org overlay: globex ---" in content
+        assert "# --- overlay: globex ---" in content
         assert "Globex-specific rules." in content
         # Verify ordering: acme before globex
         assert content.index("acme") < content.index("globex")

--- a/tests/test_globals.py
+++ b/tests/test_globals.py
@@ -12,7 +12,7 @@ from loadout.config import LoadoutConfig
 from loadout.globals import (
     _install_org_globals_scripts,
     _read_package_list,
-    _run_base_globals_script,
+    _run_globals_script,
     ensure_claude_code,
     ensure_nvm_node,
     ensure_pyenv_python,
@@ -170,29 +170,25 @@ def test_install_pip_globals_installs_missing(mock_run: MagicMock) -> None:
 
 
 # ---------------------------------------------------------------------------
-# _run_base_globals_script
+# _run_globals_script
 # ---------------------------------------------------------------------------
 
 
 @patch("loadout.globals.run")
-def test_run_base_globals_script(mock_run: MagicMock, tmp_path: Path) -> None:
-    """Should execute base globals script via bash -euo pipefail."""
-    script_dir = tmp_path / ".dotfiles" / "globals"
-    script_dir.mkdir(parents=True)
-    script = script_dir / "globals.base.sh"
+def test_run_globals_script(mock_run: MagicMock, tmp_path: Path) -> None:
+    """Should execute a globals script via bash -euo pipefail."""
+    script = tmp_path / "globals.base.sh"
     script.write_text("#!/bin/bash\necho hello\n", encoding="utf-8")
 
-    config = LoadoutConfig(base_dir=tmp_path)
-    _run_base_globals_script(config)
+    _run_globals_script(script)
 
     mock_run.assert_called_once_with(["bash", "-euo", "pipefail", str(script)], dry_run=False)
 
 
 @patch("loadout.globals.run")
-def test_run_base_globals_script_missing(mock_run: MagicMock, tmp_path: Path) -> None:
-    """Should skip gracefully when base globals script is missing."""
-    config = LoadoutConfig(base_dir=tmp_path)
-    _run_base_globals_script(config)
+def test_run_globals_script_missing(mock_run: MagicMock, tmp_path: Path) -> None:
+    """Should skip gracefully when globals script is missing."""
+    _run_globals_script(tmp_path / "nonexistent.sh")
     mock_run.assert_not_called()
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -51,11 +51,15 @@ def test_run_init_full_flow(
 
     run_init("testuser", ["orgA", "orgB"], base_dir=tmp_path)
 
-    # 2. SSH keygen
+    # 1. Xcode CLI Tools check (via runner.run)
+    xcode_calls = [c for c in mock_run.call_args_list if "xcode-select" in c.args[0]]
+    assert len(xcode_calls) == 1
+
+    # 3. SSH keygen
     keygen_calls = [c for c in mock_run.call_args_list if "ssh-keygen" in c.args[0]]
     assert len(keygen_calls) == 1
 
-    # 3. SSH key registration (bash pipeline)
+    # 4. SSH key registration (bash pipeline)
     bash_calls = [
         c
         for c in mock_run.call_args_list
@@ -63,29 +67,29 @@ def test_run_init_full_flow(
     ]
     assert len(bash_calls) == 1
 
-    # 4. Switch remotes — repo names should NOT have leading dot
+    # 5. Switch remotes — repo names should NOT have leading dot
     set_url_calls = [c for c in mock_run.call_args_list if "set-url" in c.args[0]]
     assert len(set_url_calls) == 2
     for c in set_url_calls:
         url = c.args[0][-1]
         assert "/." not in url, f"URL should not have leading dot: {url}"
 
-    # 5. Build dotfiles
+    # 6. Build dotfiles
     mock_build.assert_called_once()
 
-    # 6. Brew bundle
+    # 7. Brew bundle
     mock_brew.assert_called_once()
 
-    # 7. Install globals
+    # 8. Install globals
     mock_globals.assert_called_once()
 
-    # 8. Build Claude config
+    # 9. Build Claude config
     mock_claude.assert_called_once()
 
-    # 9. Apply macOS defaults
+    # 10. Apply macOS defaults
     mock_macos_defaults.assert_called_once()
 
-    # 11. Save config
+    # 12. Save config
     mock_save.assert_called_once()
     saved_config = mock_save.call_args.args[0]
     assert saved_config.user == "testuser"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,13 +23,20 @@ from loadout.config import LoadoutConfig, load_config, save_config
 FIXTURES = Path(__file__).parent / "fixtures"
 
 
-def _setup_from_fixtures(tmp_path: Path, orgs: list[str]) -> LoadoutConfig:
+def _setup_from_fixtures(
+    tmp_path: Path, orgs: list[str], *, include_private_base: bool = True
+) -> LoadoutConfig:
     """Copy fixture dotfiles into a temp dir and return a config pointing there."""
     dotfiles_dest = tmp_path / ".dotfiles"
     private_dest = tmp_path / ".dotfiles-private"
 
     shutil.copytree(FIXTURES / "dotfiles", dotfiles_dest)
     shutil.copytree(FIXTURES / "dotfiles-private", private_dest)
+
+    if not include_private_base:
+        private_base = private_dest / "dotfiles" / "base"
+        if private_base.exists():
+            shutil.rmtree(private_base)
 
     return LoadoutConfig(user="testuser", orgs=orgs, base_dir=tmp_path)
 
@@ -42,13 +49,13 @@ class TestBuildIntegration:
 
     def test_single_org_concat(self, tmp_path: Path) -> None:
         """Concat strategy merges base + org for .zshrc and .aliases."""
-        config = _setup_from_fixtures(tmp_path, ["acme"])
+        config = _setup_from_fixtures(tmp_path, include_private_base=False, orgs=["acme"])
         build_dotfiles(config)
 
         zshrc = (tmp_path / ".zshrc").read_text(encoding="utf-8")
         assert "export PATH" in zshrc  # from base
         assert "ACME_ENV" in zshrc  # from acme org
-        assert "# --- org overlay: acme ---" in zshrc
+        assert "# --- overlay: acme ---" in zshrc
 
         aliases = (tmp_path / ".aliases").read_text(encoding="utf-8")
         assert 'alias ll="ls -la"' in aliases  # from base
@@ -56,7 +63,7 @@ class TestBuildIntegration:
 
     def test_single_org_gitconfig_includes(self, tmp_path: Path) -> None:
         """Gitconfig strategy creates include directives and .gitconfig.d/."""
-        config = _setup_from_fixtures(tmp_path, ["acme"])
+        config = _setup_from_fixtures(tmp_path, include_private_base=False, orgs=["acme"])
         build_dotfiles(config)
 
         gitconfig = (tmp_path / ".gitconfig").read_text(encoding="utf-8")
@@ -71,7 +78,7 @@ class TestBuildIntegration:
 
     def test_single_org_json_deep_merge(self, tmp_path: Path) -> None:
         """JSON strategy deep-merges, org wins on conflict."""
-        config = _setup_from_fixtures(tmp_path, ["acme"])
+        config = _setup_from_fixtures(tmp_path, include_private_base=False, orgs=["acme"])
         build_dotfiles(config)
 
         data = json.loads((tmp_path / "settings.json").read_text(encoding="utf-8"))
@@ -83,7 +90,7 @@ class TestBuildIntegration:
 
     def test_single_org_yaml_deep_merge(self, tmp_path: Path) -> None:
         """YAML strategy deep-merges, org wins on conflict."""
-        config = _setup_from_fixtures(tmp_path, ["acme"])
+        config = _setup_from_fixtures(tmp_path, include_private_base=False, orgs=["acme"])
         build_dotfiles(config)
 
         data = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
@@ -94,7 +101,7 @@ class TestBuildIntegration:
 
     def test_single_org_replace(self, tmp_path: Path) -> None:
         """Replace strategy fully replaces base file with org file."""
-        config = _setup_from_fixtures(tmp_path, ["acme"])
+        config = _setup_from_fixtures(tmp_path, include_private_base=False, orgs=["acme"])
         build_dotfiles(config)
 
         vimrc = (tmp_path / ".vimrc").read_text(encoding="utf-8")
@@ -103,19 +110,23 @@ class TestBuildIntegration:
 
     def test_multiple_orgs_cumulative_concat(self, tmp_path: Path) -> None:
         """Multiple orgs concatenate cumulatively on .zshrc."""
-        config = _setup_from_fixtures(tmp_path, ["acme", "widgets"])
+        config = _setup_from_fixtures(
+            tmp_path, include_private_base=False, orgs=["acme", "widgets"]
+        )
         build_dotfiles(config)
 
         zshrc = (tmp_path / ".zshrc").read_text(encoding="utf-8")
         assert "export PATH" in zshrc  # base
         assert "ACME_ENV" in zshrc  # acme
         assert "WIDGETS_API" in zshrc  # widgets
-        assert "# --- org overlay: acme ---" in zshrc
-        assert "# --- org overlay: widgets ---" in zshrc
+        assert "# --- overlay: acme ---" in zshrc
+        assert "# --- overlay: widgets ---" in zshrc
 
     def test_multiple_orgs_gitconfig_includes(self, tmp_path: Path) -> None:
         """Both orgs get include directives in .gitconfig."""
-        config = _setup_from_fixtures(tmp_path, ["acme", "widgets"])
+        config = _setup_from_fixtures(
+            tmp_path, include_private_base=False, orgs=["acme", "widgets"]
+        )
         build_dotfiles(config)
 
         gitconfig = (tmp_path / ".gitconfig").read_text(encoding="utf-8")
@@ -126,7 +137,9 @@ class TestBuildIntegration:
 
     def test_multiple_orgs_json_layered_merge(self, tmp_path: Path) -> None:
         """Second org's JSON values override first org's on conflict."""
-        config = _setup_from_fixtures(tmp_path, ["acme", "widgets"])
+        config = _setup_from_fixtures(
+            tmp_path, include_private_base=False, orgs=["acme", "widgets"]
+        )
         build_dotfiles(config)
 
         data = json.loads((tmp_path / "settings.json").read_text(encoding="utf-8"))
@@ -136,7 +149,9 @@ class TestBuildIntegration:
 
     def test_multiple_orgs_yaml_layered_merge(self, tmp_path: Path) -> None:
         """Second org's YAML values override first org's on conflict."""
-        config = _setup_from_fixtures(tmp_path, ["acme", "widgets"])
+        config = _setup_from_fixtures(
+            tmp_path, include_private_base=False, orgs=["acme", "widgets"]
+        )
         build_dotfiles(config)
 
         data = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
@@ -148,7 +163,7 @@ class TestBuildIntegration:
 
     def test_build_creates_build_dir(self, tmp_path: Path) -> None:
         """Build dir is created and contains intermediate files."""
-        config = _setup_from_fixtures(tmp_path, ["acme"])
+        config = _setup_from_fixtures(tmp_path, include_private_base=False, orgs=["acme"])
         build_dotfiles(config)
 
         assert config.build_dir.exists()
@@ -156,7 +171,7 @@ class TestBuildIntegration:
 
     def test_build_is_idempotent(self, tmp_path: Path) -> None:
         """Running build twice produces the same output."""
-        config = _setup_from_fixtures(tmp_path, ["acme"])
+        config = _setup_from_fixtures(tmp_path, include_private_base=False, orgs=["acme"])
 
         build_dotfiles(config)
         first_zshrc = (tmp_path / ".zshrc").read_text(encoding="utf-8")
@@ -171,21 +186,126 @@ class TestBuildIntegration:
 
     def test_no_orgs_base_only(self, tmp_path: Path) -> None:
         """With no orgs, base files are installed unmodified."""
-        config = _setup_from_fixtures(tmp_path, [])
+        config = _setup_from_fixtures(tmp_path, include_private_base=False, orgs=[])
         build_dotfiles(config)
 
         zshrc = (tmp_path / ".zshrc").read_text(encoding="utf-8")
         assert "export PATH" in zshrc
-        assert "org overlay" not in zshrc
+        assert "# --- overlay:" not in zshrc
 
     def test_nonexistent_org_graceful(self, tmp_path: Path) -> None:
         """A non-existent org in the config is silently skipped."""
-        config = _setup_from_fixtures(tmp_path, ["acme", "nonexistent"])
+        config = _setup_from_fixtures(
+            tmp_path, include_private_base=False, orgs=["acme", "nonexistent"]
+        )
         build_dotfiles(config)
 
         zshrc = (tmp_path / ".zshrc").read_text(encoding="utf-8")
         assert "ACME_ENV" in zshrc
         assert "nonexistent" not in zshrc
+
+
+# ── Private base layer integration ─────────────────────────────────────────
+
+
+class TestPrivateBaseBuildIntegration:
+    """Build tests exercising the private base layer between public base and orgs."""
+
+    def test_private_base_only_no_orgs(self, tmp_path: Path) -> None:
+        """Private base merges on top of public base when no orgs are configured."""
+        config = _setup_from_fixtures(tmp_path, orgs=[])
+        build_dotfiles(config)
+
+        # Concat: public base + private base
+        zshrc = (tmp_path / ".zshrc").read_text(encoding="utf-8")
+        assert "export PATH" in zshrc  # from public base
+        assert "PRIVATE_BASE_VAR" in zshrc  # from private base
+        assert "# --- overlay: private-base ---" in zshrc
+
+        # JSON deep-merge: private base wins on conflict
+        data = json.loads((tmp_path / "settings.json").read_text(encoding="utf-8"))
+        assert data["editor"] == "vim"  # from public base
+        assert data["theme"] == "private-dark"  # private base wins over "dark"
+        assert data["private_flag"] is True  # from private base
+
+        # YAML deep-merge
+        ydata = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+        assert ydata["opts"]["pager"] == "bat-private"  # private base wins over "less"
+
+        # Replace: private base replaces public base
+        vimrc = (tmp_path / ".vimrc").read_text(encoding="utf-8")
+        assert "tabstop=3" in vimrc  # from private base
+        assert "set number" not in vimrc  # public base is gone
+
+    def test_private_base_plus_single_org(self, tmp_path: Path) -> None:
+        """Three-layer merge: org wins over private base, which wins over public base."""
+        config = _setup_from_fixtures(tmp_path, orgs=["acme"])
+        build_dotfiles(config)
+
+        # JSON: org wins over private base
+        data = json.loads((tmp_path / "settings.json").read_text(encoding="utf-8"))
+        assert data["editor"] == "vim"  # public base survives
+        assert data["theme"] == "light"  # acme wins over private-dark
+        assert data["private_flag"] is True  # private base survives (acme doesn't override)
+        assert data["acme_specific"] is True  # from acme
+
+        # YAML: org wins over private base
+        ydata = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+        assert ydata["opts"]["pager"] == "bat"  # acme wins over bat-private
+
+    def test_private_base_plus_multiple_orgs(self, tmp_path: Path) -> None:
+        """Full stack: public base < private base < acme < widgets."""
+        config = _setup_from_fixtures(tmp_path, orgs=["acme", "widgets"])
+        build_dotfiles(config)
+
+        data = json.loads((tmp_path / "settings.json").read_text(encoding="utf-8"))
+        assert data["editor"] == "vim"  # public base survives
+        assert data["theme"] == "solarized"  # widgets wins over all
+        assert data["private_flag"] is True  # private base survives
+
+        ydata = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+        assert ydata["opts"]["pager"] == "more"  # widgets wins
+
+    def test_private_base_concat_ordering(self, tmp_path: Path) -> None:
+        """Concat output contains separators in correct order."""
+        config = _setup_from_fixtures(tmp_path, orgs=["acme"])
+        build_dotfiles(config)
+
+        zshrc = (tmp_path / ".zshrc").read_text(encoding="utf-8")
+        pb_pos = zshrc.index("# --- overlay: private-base ---")
+        org_pos = zshrc.index("# --- overlay: acme ---")
+        assert pb_pos < org_pos  # private base before org
+
+    def test_private_base_gitconfig_include(self, tmp_path: Path) -> None:
+        """Gitconfig includes private-base before org includes."""
+        config = _setup_from_fixtures(tmp_path, orgs=["acme"])
+        build_dotfiles(config)
+
+        gitconfig = (tmp_path / ".gitconfig").read_text(encoding="utf-8")
+        assert "path = ~/.gitconfig.d/private-base" in gitconfig
+        assert "path = ~/.gitconfig.d/acme" in gitconfig
+
+        pb_pos = gitconfig.index("path = ~/.gitconfig.d/private-base")
+        org_pos = gitconfig.index("path = ~/.gitconfig.d/acme")
+        assert pb_pos < org_pos  # private-base included before org
+
+        pb_file = tmp_path / ".gitconfig.d" / "private-base"
+        assert pb_file.exists()
+        assert "editor = nano" in pb_file.read_text(encoding="utf-8")
+
+    def test_private_base_absent_backwards_compatible(self, tmp_path: Path) -> None:
+        """When private base dir is absent, behavior matches original two-layer model."""
+        config = _setup_from_fixtures(tmp_path, include_private_base=False, orgs=["acme"])
+        build_dotfiles(config)
+
+        zshrc = (tmp_path / ".zshrc").read_text(encoding="utf-8")
+        assert "PRIVATE_BASE_VAR" not in zshrc
+        assert "# --- overlay: private-base ---" not in zshrc
+        assert "# --- overlay: acme ---" in zshrc
+
+        data = json.loads((tmp_path / "settings.json").read_text(encoding="utf-8"))
+        assert data["theme"] == "light"  # acme wins over public base directly
+        assert "private_flag" not in data
 
 
 # ── Config round-trip integration ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds a **private base** layer to the merge pipeline, creating a three-layer model: public base → private base → org overlays. This lets users define personal private preferences (SSH config, aliases, MCP servers, etc.) that apply across all orgs without being public or relying on a "personal" org workaround.
- Adds **Xcode CLI Tools** detection and headless install as step 1 of `loadout init`, since git and Homebrew depend on it.
- Extracts `_apply_overlay()` helper in `build.py` to eliminate strategy dispatch duplication between private base and org overlay application.

All five subsystems updated consistently: dotfile build, Brewfile assembly, Claude config, globals, and health checks. The private base layer is optional — when the directory doesn't exist, behavior is identical to before.

Closes #46

## Test plan

- [ ] `pytest` — 257 tests pass (6 new private base integration tests, existing tests updated)
- [ ] `ruff check` / `ruff format --check` / `mypy` all pass
- [ ] Verify CI passes on all 6 matrix combos (Python 3.11-3.13 × ubuntu/macos)
- [ ] Manual: `loadout build --dry-run` shows private base layer when `~/.dotfiles-private/dotfiles/base/` exists
- [ ] Manual: `loadout build --dry-run` behaves identically when private base dir is absent