### PR TITLE
Add canvas and devbox CLI installation to loadout init

### DIFF
--- a/loadout/globals.py
+++ b/loadout/globals.py
@@ -29,6 +29,22 @@ def ensure_claude_code(*, dry_run: bool = False) -> None:
     )
 
 
+def ensure_devbox(*, dry_run: bool = False) -> None:
+    """Install devbox CLI if not already present."""
+    if shutil.which("devbox") is not None:
+        status_line("[green]✓[/green]", "devbox CLI", "already installed")
+        return
+    run(["pip3", "install", "oakensoul-devbox"], dry_run=dry_run)
+
+
+def ensure_canvas(*, dry_run: bool = False) -> None:
+    """Install canvas CLI if not already present."""
+    if shutil.which("canvas") is not None:
+        status_line("[green]✓[/green]", "canvas CLI", "already installed")
+        return
+    run(["pip3", "install", "oakensoul-canvas"], dry_run=dry_run)
+
+
 def ensure_nvm_node(config: LoadoutConfig, *, dry_run: bool = False) -> None:
     """Install NVM and Node LTS if not already present."""
     nvm_dir = config.home / ".nvm"
@@ -150,6 +166,8 @@ def install_globals(config: LoadoutConfig, *, dry_run: bool = False) -> None:
         lambda: ensure_nvm_node(config, dry_run=dry_run),
     )
     run_step("Ensure Claude Code CLI", lambda: ensure_claude_code(dry_run=dry_run))
+    run_step("Ensure devbox CLI", lambda: ensure_devbox(dry_run=dry_run))
+    run_step("Ensure canvas CLI", lambda: ensure_canvas(dry_run=dry_run))
     run_step("Ensure pyenv Python", lambda: ensure_pyenv_python(config, dry_run=dry_run))
 
     run_step(

--- a/loadout/init.py
+++ b/loadout/init.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import json
 import shlex
 import shutil
 import socket
@@ -187,6 +188,39 @@ def _setup_launch_agent(
     runner.run(["launchctl", "load", str(plist_path)], dry_run=dry_run)
 
 
+def _bootstrap_canvas_config(
+    config: LoadoutConfig,
+    *,
+    dry_run: bool = False,
+) -> None:
+    """Create ~/.canvas/config.json with default org if it doesn't exist."""
+    if shutil.which("canvas") is None:
+        ui.status_line("[dim]⏭[/dim]", "Canvas config", "skipped (canvas not installed)")
+        return
+
+    if not config.orgs:
+        ui.status_line("[dim]⏭[/dim]", "Canvas config", "skipped (no orgs configured)")
+        return
+
+    canvas_dir = config.home / ".canvas"
+    config_path = canvas_dir / "config.json"
+
+    if config_path.exists():
+        ui.status_line("[green]✓[/green]", "Canvas config", "already exists")
+        return
+
+    if dry_run:
+        ui.status_line("[dim]▶[/dim]", "Canvas config", "would create (dry run)")
+        return
+
+    canvas_dir.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        json.dumps({"org": config.orgs[0]}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    ui.status_line("[green]✓[/green]", "Canvas config", f"created with org={config.orgs[0]}")
+
+
 def run_init(
     user: str,
     orgs: list[str],
@@ -279,19 +313,25 @@ def run_init(
         lambda: build_claude_config(config, dry_run=dry_run),
     )
 
-    # 10. Apply macOS defaults
+    # 10. Bootstrap canvas config
+    ui.run_step(
+        "Bootstrap canvas config",
+        lambda: _bootstrap_canvas_config(config, dry_run=dry_run),
+    )
+
+    # 11. Apply macOS defaults
     ui.run_step(
         "Apply macOS defaults",
         lambda: apply_macos_defaults(config, dry_run=dry_run),
     )
 
-    # 11. Set up display launch agent
+    # 12. Set up display launch agent
     ui.run_step(
         "Set up display launch agent",
         lambda: _setup_launch_agent(config, dry_run=dry_run),
     )
 
-    # 12. Save config
+    # 13. Save config
     if not dry_run:
         ui.run_step(
             "Save config",

--- a/tests/test_globals.py
+++ b/tests/test_globals.py
@@ -13,7 +13,9 @@ from loadout.globals import (
     _install_org_globals_scripts,
     _read_package_list,
     _run_globals_script,
+    ensure_canvas,
     ensure_claude_code,
+    ensure_devbox,
     ensure_nvm_node,
     ensure_pyenv_python,
     install_globals,
@@ -52,6 +54,76 @@ def test_ensure_claude_code_dry_run(mock_which: MagicMock, mock_run: MagicMock) 
     ensure_claude_code(dry_run=True)
     mock_run.assert_called_once_with(
         ["bash", "-c", "curl -fsSL https://claude.ai/install.sh | bash"],
+        dry_run=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ensure_devbox
+# ---------------------------------------------------------------------------
+
+
+@patch("loadout.globals.run")
+@patch("loadout.globals.shutil.which", return_value="/usr/local/bin/devbox")
+def test_ensure_devbox_already_installed(mock_which: MagicMock, mock_run: MagicMock) -> None:
+    """Should skip install when devbox is already on PATH."""
+    ensure_devbox()
+    mock_run.assert_not_called()
+
+
+@patch("loadout.globals.run")
+@patch("loadout.globals.shutil.which", return_value=None)
+def test_ensure_devbox_installs(mock_which: MagicMock, mock_run: MagicMock) -> None:
+    """Should install via pip3 when devbox is not on PATH."""
+    ensure_devbox()
+    mock_run.assert_called_once_with(
+        ["pip3", "install", "oakensoul-devbox"],
+        dry_run=False,
+    )
+
+
+@patch("loadout.globals.run")
+@patch("loadout.globals.shutil.which", return_value=None)
+def test_ensure_devbox_dry_run(mock_which: MagicMock, mock_run: MagicMock) -> None:
+    """Dry-run should pass dry_run=True to runner."""
+    ensure_devbox(dry_run=True)
+    mock_run.assert_called_once_with(
+        ["pip3", "install", "oakensoul-devbox"],
+        dry_run=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ensure_canvas
+# ---------------------------------------------------------------------------
+
+
+@patch("loadout.globals.run")
+@patch("loadout.globals.shutil.which", return_value="/usr/local/bin/canvas")
+def test_ensure_canvas_already_installed(mock_which: MagicMock, mock_run: MagicMock) -> None:
+    """Should skip install when canvas is already on PATH."""
+    ensure_canvas()
+    mock_run.assert_not_called()
+
+
+@patch("loadout.globals.run")
+@patch("loadout.globals.shutil.which", return_value=None)
+def test_ensure_canvas_installs(mock_which: MagicMock, mock_run: MagicMock) -> None:
+    """Should install via pip3 when canvas is not on PATH."""
+    ensure_canvas()
+    mock_run.assert_called_once_with(
+        ["pip3", "install", "oakensoul-canvas"],
+        dry_run=False,
+    )
+
+
+@patch("loadout.globals.run")
+@patch("loadout.globals.shutil.which", return_value=None)
+def test_ensure_canvas_dry_run(mock_which: MagicMock, mock_run: MagicMock) -> None:
+    """Dry-run should pass dry_run=True to runner."""
+    ensure_canvas(dry_run=True)
+    mock_run.assert_called_once_with(
+        ["pip3", "install", "oakensoul-canvas"],
         dry_run=True,
     )
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from loadout.config import LoadoutConfig
-from loadout.init import run_init
+from loadout.init import _bootstrap_canvas_config, run_init
 
 
 def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
@@ -377,3 +377,71 @@ def test_run_init_non_macos_skips_launch_agent(
 
     plist_path = tmp_path / "Library" / "LaunchAgents" / "com.oakensoul.loadout.display.plist"
     assert not plist_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Canvas config bootstrap
+# ---------------------------------------------------------------------------
+
+
+@patch("loadout.init.shutil.which", return_value="/usr/local/bin/canvas")
+def test_bootstrap_canvas_config_creates_file(mock_which: MagicMock, tmp_path: Path) -> None:
+    """Should create ~/.canvas/config.json with first org."""
+    config = LoadoutConfig(user="testuser", orgs=["myorg", "other"], base_dir=tmp_path)
+    _bootstrap_canvas_config(config)
+
+    config_path = tmp_path / ".canvas" / "config.json"
+    assert config_path.exists()
+    import json
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert data == {"org": "myorg"}
+
+
+@patch("loadout.init.shutil.which", return_value="/usr/local/bin/canvas")
+def test_bootstrap_canvas_config_skips_if_exists(mock_which: MagicMock, tmp_path: Path) -> None:
+    """Should not overwrite existing config."""
+    canvas_dir = tmp_path / ".canvas"
+    canvas_dir.mkdir()
+    config_path = canvas_dir / "config.json"
+    config_path.write_text('{"org": "existing"}', encoding="utf-8")
+
+    config = LoadoutConfig(user="testuser", orgs=["neworg"], base_dir=tmp_path)
+    _bootstrap_canvas_config(config)
+
+    import json
+
+    data = json.loads(config_path.read_text(encoding="utf-8"))
+    assert data == {"org": "existing"}
+
+
+@patch("loadout.init.shutil.which", return_value=None)
+def test_bootstrap_canvas_config_skips_if_not_installed(
+    mock_which: MagicMock, tmp_path: Path
+) -> None:
+    """Should skip when canvas CLI is not installed."""
+    config = LoadoutConfig(user="testuser", orgs=["myorg"], base_dir=tmp_path)
+    _bootstrap_canvas_config(config)
+
+    config_path = tmp_path / ".canvas" / "config.json"
+    assert not config_path.exists()
+
+
+@patch("loadout.init.shutil.which", return_value="/usr/local/bin/canvas")
+def test_bootstrap_canvas_config_skips_if_no_orgs(mock_which: MagicMock, tmp_path: Path) -> None:
+    """Should skip when no orgs are configured."""
+    config = LoadoutConfig(user="testuser", orgs=[], base_dir=tmp_path)
+    _bootstrap_canvas_config(config)
+
+    config_path = tmp_path / ".canvas" / "config.json"
+    assert not config_path.exists()
+
+
+@patch("loadout.init.shutil.which", return_value="/usr/local/bin/canvas")
+def test_bootstrap_canvas_config_dry_run(mock_which: MagicMock, tmp_path: Path) -> None:
+    """Dry-run should not create the config file."""
+    config = LoadoutConfig(user="testuser", orgs=["myorg"], base_dir=tmp_path)
+    _bootstrap_canvas_config(config, dry_run=True)
+
+    config_path = tmp_path / ".canvas" / "config.json"
+    assert not config_path.exists()


### PR DESCRIPTION
## Summary
- Added `ensure_devbox()` and `ensure_canvas()` to globals.py following the existing `ensure_*` pattern (check via `shutil.which`, install via `pip3`)
- Added canvas config bootstrap step to init.py — creates `~/.canvas/config.json` with first org from config
- Canvas config step guards: skips if canvas not installed, no orgs configured, or config already exists

Closes #50

## Test plan
- [x] All 285 tests pass with 95.72% coverage
- [x] 6 new globals tests (ensure_devbox + ensure_canvas: installed/install/dry-run)
- [x] 5 new init tests (canvas config: creates/skip-exists/skip-no-canvas/skip-no-orgs/dry-run)
- [x] ruff check + format clean