### PR TITLE
Move cookiecutter from optional to core dependency

### DIFF
--- a/loadout/scaffold.py
+++ b/loadout/scaffold.py
@@ -7,21 +7,12 @@ from __future__ import annotations
 import shutil
 from pathlib import Path
 
+from cookiecutter.main import cookiecutter as run_cookiecutter
+
 from loadout import runner, ui
 from loadout.exceptions import LoadoutError
 
 _DEFAULT_TEMPLATE = "https://github.com/oakensoul/dotfiles-private-cookiecutter"
-
-
-def _check_cookiecutter() -> None:
-    """Verify that cookiecutter is importable, raising a clear error if not."""
-    try:
-        import cookiecutter  # noqa: F401
-    except ImportError:
-        raise LoadoutError(
-            "cookiecutter is not installed. "
-            'Install it with: pip install "oakensoul-loadout[scaffold]"'
-        ) from None
 
 
 def _build_context(
@@ -71,10 +62,7 @@ def run_scaffold(
 
     ui.section_header("Scaffold dotfiles-private")
 
-    # 1. Check cookiecutter is available
-    ui.run_step("Check cookiecutter dependency", _check_cookiecutter)
-
-    # 2. Check target directory does not exist
+    # 1. Check target directory does not exist
     def _check_target() -> None:
         if target_dir.exists():
             raise LoadoutError(
@@ -87,11 +75,11 @@ def run_scaffold(
 
     ui.run_step("Check target directory", _check_target)
 
-    # 3. Build context
+    # 2. Build context
     context = _build_context(user, orgs, git_name, git_email)
 
-    # 4. Run cookiecutter
-    def _run_cookiecutter() -> None:
+    # 3. Run cookiecutter
+    def _run_cookiecutter_step() -> None:
         if dry_run:
             ui.status_line(
                 "[dim]\u25b6[/dim]",
@@ -100,8 +88,6 @@ def run_scaffold(
             )
             return
 
-        from cookiecutter.main import cookiecutter as run_cookiecutter
-
         run_cookiecutter(
             template,
             no_input=True,
@@ -109,9 +95,9 @@ def run_scaffold(
             output_dir=str(home),
         )
 
-    ui.run_step("Run cookiecutter template", _run_cookiecutter)
+    ui.run_step("Run cookiecutter template", _run_cookiecutter_step)
 
-    # 5. Rename output directory to ~/.dotfiles-private
+    # 4. Rename output directory to ~/.dotfiles-private
     def _rename_output() -> None:
         # cookiecutter typically outputs to {output_dir}/{project_slug}
         # The template should produce a directory named {github_username}-dotfiles-private
@@ -149,7 +135,7 @@ def run_scaffold(
 
     ui.run_step("Rename output directory", _rename_output)
 
-    # 6. Create GitHub repo if requested
+    # 5. Create GitHub repo if requested
     if create_repo:
 
         def _create_repo() -> None:
@@ -176,7 +162,7 @@ def run_scaffold(
 
         ui.run_step("Create GitHub repository", _create_repo)
 
-    # 7. Success message
+    # 6. Success message
     ui.console.print()
     ui.console.print("[green]Scaffold complete![/green]")
     ui.console.print()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.0",
+    "cookiecutter>=2.0",
     "pyyaml>=6.0",
     "rich>=13.0",
 ]
@@ -36,7 +37,6 @@ Repository = "https://github.com/oakensoul/loadout"
 Issues = "https://github.com/oakensoul/loadout/issues"
 
 [project.optional-dependencies]
-scaffold = ["cookiecutter>=2.0"]
 dev = [
     "build>=1.0",
     "cyclonedx-bom>=4.0",

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from loadout.exceptions import LoadoutError
-from loadout.scaffold import _build_context, _check_cookiecutter, run_scaffold
+from loadout.scaffold import _build_context, run_scaffold
 
 
 def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
@@ -19,16 +19,11 @@ def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[s
     return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
 
-def _noop_check() -> None:
-    """No-op replacement for _check_cookiecutter in tests."""
-
-
 # ---------------------------------------------------------------------------
 # Successful scaffold
 # ---------------------------------------------------------------------------
 
 
-@patch("loadout.scaffold._check_cookiecutter", _noop_check)
 @patch("loadout.scaffold.shutil.which", return_value="/usr/bin/gh")
 @patch("loadout.scaffold.runner.run", side_effect=_fake_run)
 def test_scaffold_creates_directory(
@@ -49,12 +44,7 @@ def test_scaffold_creates_directory(
         (expected_output / "README.md").write_text("# test", encoding="utf-8")
         return str(expected_output)
 
-    mock_cc = MagicMock()
-    mock_cc_main = MagicMock(cookiecutter=fake_cookiecutter)
-    with patch.dict(
-        "sys.modules",
-        {"cookiecutter": mock_cc, "cookiecutter.main": mock_cc_main},
-    ):
+    with patch("loadout.scaffold.run_cookiecutter", side_effect=fake_cookiecutter):
         run_scaffold(
             "testuser",
             ["orgA", "orgB"],
@@ -74,7 +64,6 @@ def test_scaffold_creates_directory(
 # ---------------------------------------------------------------------------
 
 
-@patch("loadout.scaffold._check_cookiecutter", _noop_check)
 def test_scaffold_aborts_when_target_exists(tmp_path: Path) -> None:
     """Scaffold should raise LoadoutError if ~/.dotfiles-private exists."""
     (tmp_path / ".dotfiles-private").mkdir()
@@ -94,7 +83,6 @@ def test_scaffold_aborts_when_target_exists(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("loadout.scaffold._check_cookiecutter", _noop_check)
 @patch("loadout.scaffold.shutil.which", return_value="/usr/bin/gh")
 @patch("loadout.scaffold.runner.run", side_effect=_fake_run)
 def test_scaffold_create_repo_calls_gh(
@@ -114,12 +102,7 @@ def test_scaffold_create_repo_calls_gh(
         expected_output.mkdir()
         return str(expected_output)
 
-    mock_cc = MagicMock()
-    mock_cc_main = MagicMock(cookiecutter=fake_cookiecutter)
-    with patch.dict(
-        "sys.modules",
-        {"cookiecutter": mock_cc, "cookiecutter.main": mock_cc_main},
-    ):
+    with patch("loadout.scaffold.run_cookiecutter", side_effect=fake_cookiecutter):
         run_scaffold(
             "testuser",
             ["org1"],
@@ -142,7 +125,6 @@ def test_scaffold_create_repo_calls_gh(
 # ---------------------------------------------------------------------------
 
 
-@patch("loadout.scaffold._check_cookiecutter", _noop_check)
 def test_scaffold_dry_run_no_files(tmp_path: Path) -> None:
     """Dry run should not create any files."""
     run_scaffold(
@@ -157,20 +139,6 @@ def test_scaffold_dry_run_no_files(tmp_path: Path) -> None:
 
     target = tmp_path / ".dotfiles-private"
     assert not target.exists()
-
-
-# ---------------------------------------------------------------------------
-# Missing cookiecutter raises clear error
-# ---------------------------------------------------------------------------
-
-
-def test_scaffold_missing_cookiecutter_raises_error() -> None:
-    """Should raise LoadoutError with install instructions."""
-    with (
-        patch.dict("sys.modules", {"cookiecutter": None}),
-        pytest.raises(LoadoutError, match="cookiecutter is not installed"),
-    ):
-        _check_cookiecutter()
 
 
 # ---------------------------------------------------------------------------
@@ -210,7 +178,6 @@ def test_scaffold_empty_orgs_context() -> None:
 # ---------------------------------------------------------------------------
 
 
-@patch("loadout.scaffold._check_cookiecutter", _noop_check)
 @patch("loadout.scaffold.runner.run", side_effect=_fake_run)
 def test_scaffold_dry_run_with_create_repo(
     mock_run: MagicMock,


### PR DESCRIPTION
## Summary
- Moved `cookiecutter>=2.0` from `[project.optional-dependencies]` to `dependencies`
- Removed `_check_cookiecutter()` guard and import cookiecutter at module level
- Removed related test (`test_scaffold_missing_cookiecutter_raises_error`)
- cookiecutter is always available via pyenv, no separate install step needed

## Test plan
- [x] 293 tests pass, 95.10% coverage
- [x] ruff + mypy clean