### PR TITLE
fix: prevent devbox users from corrupting system Homebrew ownership

### DIFF
--- a/loadout/brew.py
+++ b/loadout/brew.py
@@ -4,12 +4,13 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import tempfile
 from pathlib import Path
 
 from loadout.config import LoadoutConfig
-from loadout.runner import run
+from loadout.runner import brew_prefix_is_owned, detect_brew_bin, run
 from loadout.ui import status_line, verbose_line
 
 
@@ -57,6 +58,16 @@ def brew_bundle(config: LoadoutConfig, *, dry_run: bool = False) -> None:
     """
     if shutil.which("brew") is None:
         status_line("[yellow]![/yellow]", "Homebrew", "not found — skipping")
+        return
+
+    if not brew_prefix_is_owned():
+        brew_bin = detect_brew_bin()
+        prefix = os.path.dirname(brew_bin) if brew_bin else "unknown"
+        status_line(
+            "[yellow]![/yellow]",
+            "Homebrew",
+            f"{prefix} is owned by another user — skipping to avoid ownership conflicts",
+        )
         return
 
     fragments = _assemble_brewfile(config)

--- a/loadout/check.py
+++ b/loadout/check.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -12,6 +13,7 @@ from enum import Enum
 
 from loadout import ui
 from loadout.config import LoadoutConfig
+from loadout.runner import brew_prefix_is_owned, detect_brew_bin
 
 
 class CheckStatus(Enum):
@@ -36,6 +38,33 @@ def check_homebrew() -> CheckResult:
     if shutil.which("brew"):
         return CheckResult(status=CheckStatus.OK, label="Homebrew", detail="brew found on PATH")
     return CheckResult(status=CheckStatus.ERROR, label="Homebrew", detail="brew not found on PATH")
+
+
+def check_homebrew_ownership() -> CheckResult:
+    """Verify that the detected Homebrew prefix is owned by the current user."""
+    brew_bin = detect_brew_bin()
+    if brew_bin is None:
+        return CheckResult(
+            status=CheckStatus.WARN,
+            label="Homebrew ownership",
+            detail="brew not found",
+        )
+    prefix = os.path.dirname(brew_bin)
+    if brew_prefix_is_owned():
+        return CheckResult(
+            status=CheckStatus.OK,
+            label="Homebrew ownership",
+            detail=f"{prefix} owned by current user",
+        )
+    try:
+        owner_uid = os.stat(prefix).st_uid
+    except OSError:
+        owner_uid = -1
+    return CheckResult(
+        status=CheckStatus.WARN,
+        label="Homebrew ownership",
+        detail=f"{prefix} owned by uid {owner_uid}, not current user (uid {os.getuid()})",
+    )
 
 
 def check_git() -> CheckResult:
@@ -317,6 +346,7 @@ def run_checks(config: LoadoutConfig) -> list[CheckResult]:
     """Run all health checks and return results."""
     results = [
         check_homebrew(),
+        check_homebrew_ownership(),
         check_git(),
         check_nvm_node(),
         check_pyenv_python(),

--- a/loadout/runner.py
+++ b/loadout/runner.py
@@ -36,6 +36,27 @@ def detect_brew_bin() -> str | None:
     return None
 
 
+def brew_prefix_is_owned() -> bool:
+    """Return True if the detected Homebrew prefix is owned by the current user.
+
+    Prevents devbox users (e.g. ``dx-*``) from accidentally running write
+    operations (``brew update``, ``brew bundle``, ``brew upgrade``) against
+    the parent user's Homebrew at ``/opt/homebrew``, which would take
+    ownership of shared directories and break the parent installation.
+
+    Returns ``True`` when no brew is detected — callers handle that case
+    separately.
+    """
+    brew_bin = detect_brew_bin()
+    if brew_bin is None:
+        return True
+    prefix = os.path.dirname(brew_bin)
+    try:
+        return os.stat(prefix).st_uid == os.getuid()
+    except OSError:
+        return False
+
+
 def run(
     cmd: list[str],
     *,

--- a/loadout/update.py
+++ b/loadout/update.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 
 from loadout.brew import brew_bundle
@@ -11,7 +12,7 @@ from loadout.build import build_dotfiles
 from loadout.claude import build_claude_config
 from loadout.config import LoadoutConfig
 from loadout.globals import install_globals
-from loadout.runner import run
+from loadout.runner import brew_prefix_is_owned, detect_brew_bin, run
 from loadout.secrets import load_ssh_key_config
 from loadout.ssh import install_ssh_config
 from loadout.ui import run_step, section_header, status_line
@@ -118,10 +119,19 @@ def run_upgrade(
     if skip_brew:
         status_line("[yellow]![/yellow]", "Brew upgrade", "skipped (--skip-brew)")
     elif shutil.which("brew") is not None:
-        run_step(
-            "Brew upgrade",
-            lambda: run(["brew", "upgrade"], dry_run=dry_run, interactive=True),
-            interactive=True,
-        )
+        if not brew_prefix_is_owned():
+            brew_bin = detect_brew_bin()
+            prefix = os.path.dirname(brew_bin) if brew_bin else "unknown"
+            status_line(
+                "[yellow]![/yellow]",
+                "Brew upgrade",
+                f"{prefix} is owned by another user — skipping to avoid ownership conflicts",
+            )
+        else:
+            run_step(
+                "Brew upgrade",
+                lambda: run(["brew", "upgrade"], dry_run=dry_run, interactive=True),
+                interactive=True,
+            )
     else:
         status_line("[yellow]![/yellow]", "brew", "not found — skipping brew upgrade")

--- a/tests/test_brew.py
+++ b/tests/test_brew.py
@@ -175,3 +175,25 @@ class TestBrewBundle:
         brew_bundle(config, dry_run=False)
 
         mock_run.assert_not_called()  # type: ignore[union-attr]
+
+    @patch("loadout.brew.run")
+    @patch("loadout.brew.brew_prefix_is_owned", return_value=False)
+    @patch("loadout.brew.detect_brew_bin", return_value="/opt/homebrew/bin")
+    @patch("loadout.brew.shutil.which", return_value="/opt/homebrew/bin/brew")
+    def test_brew_bundle_skips_unowned_prefix(
+        self,
+        _mock_which: object,
+        _mock_detect: object,
+        _mock_owned: object,
+        mock_run: object,
+        tmp_path: Path,
+    ) -> None:
+        config = _make_config(tmp_path)
+
+        base = config.dotfiles_dir / "brewfiles" / "Brewfile.base"
+        base.parent.mkdir(parents=True)
+        base.write_text("brew 'git'\n", encoding="utf-8")
+
+        brew_bundle(config, dry_run=False)
+
+        mock_run.assert_not_called()  # type: ignore[union-attr]

--- a/tests/test_brew.py
+++ b/tests/test_brew.py
@@ -87,10 +87,12 @@ class TestBrewBundle:
     """Tests for brew_bundle orchestration."""
 
     @patch("loadout.brew.run")
+    @patch("loadout.brew.brew_prefix_is_owned", return_value=True)
     @patch("loadout.brew.shutil.which", return_value="/opt/homebrew/bin/brew")
     def test_brew_bundle_assembles_and_runs(
         self,
         _mock_which: object,
+        _mock_owned: object,
         mock_run: object,
         tmp_path: Path,
     ) -> None:
@@ -122,10 +124,12 @@ class TestBrewBundle:
         assert not tmp_file.exists()
 
     @patch("loadout.brew.run")
+    @patch("loadout.brew.brew_prefix_is_owned", return_value=True)
     @patch("loadout.brew.shutil.which", return_value="/opt/homebrew/bin/brew")
     def test_brew_bundle_fallback_single_brewfile(
         self,
         _mock_which: object,
+        _mock_owned: object,
         mock_run: object,
         tmp_path: Path,
     ) -> None:
@@ -146,10 +150,12 @@ class TestBrewBundle:
         assert f"--file={brewfile}" in bundle_cmd
 
     @patch("loadout.brew.run")
+    @patch("loadout.brew.brew_prefix_is_owned", return_value=True)
     @patch("loadout.brew.shutil.which", return_value="/opt/homebrew/bin/brew")
     def test_brew_bundle_no_brewfile(
         self,
         _mock_which: object,
+        _mock_owned: object,
         mock_run: object,
         tmp_path: Path,
     ) -> None:

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -22,6 +22,7 @@ from loadout.check import (
     check_github_ssh,
     check_globals_scripts,
     check_homebrew,
+    check_homebrew_ownership,
     check_macos_scripts,
     check_nvm_node,
     check_onepassword,
@@ -49,6 +50,44 @@ class TestCheckHomebrew:
         result = check_homebrew()
         assert result.status == CheckStatus.ERROR
         assert "not found" in result.detail
+
+
+class TestCheckHomebrewOwnership:
+    """Tests for check_homebrew_ownership."""
+
+    def setup_method(self) -> None:
+        """Clear the brew detection cache before each test."""
+        from loadout.runner import detect_brew_bin
+
+        detect_brew_bin.cache_clear()
+
+    @patch("loadout.check.detect_brew_bin", return_value=None)
+    def test_no_brew(self, _mock_detect: object) -> None:
+        result = check_homebrew_ownership()
+        assert result.status == CheckStatus.WARN
+        assert "not found" in result.detail
+
+    @patch("loadout.check.brew_prefix_is_owned", return_value=True)
+    @patch("loadout.check.detect_brew_bin", return_value="/opt/homebrew/bin")
+    def test_owned(self, _mock_detect: object, _mock_owned: object) -> None:
+        result = check_homebrew_ownership()
+        assert result.status == CheckStatus.OK
+        assert "owned by current user" in result.detail
+
+    @patch("loadout.check.os.getuid", return_value=501)
+    @patch("loadout.check.os.stat")
+    @patch("loadout.check.brew_prefix_is_owned", return_value=False)
+    @patch("loadout.check.detect_brew_bin", return_value="/opt/homebrew/bin")
+    def test_not_owned(
+        self, _mock_detect: object, _mock_owned: object, mock_stat: object, _mock_uid: object
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        mock_stat_result = MagicMock(st_uid=602)  # type: ignore[attr-defined]
+        mock_stat.return_value = mock_stat_result  # type: ignore[union-attr]
+        result = check_homebrew_ownership()
+        assert result.status == CheckStatus.WARN
+        assert "uid 602" in result.detail
 
 
 class TestCheckGit:
@@ -372,8 +411,8 @@ class TestRunChecks:
             )
             results = run_checks(config)
         assert isinstance(results, list)
-        # 7 tool checks + brewfile fallback(1) + globals base(1) + macos(0) + claude config(1) = 10
-        assert len(results) == 10
+        # 8 tool checks + brewfile fallback(1) + globals base(1) + macos(0) + claude config(1) = 11
+        assert len(results) == 11
         assert all(isinstance(r, CheckResult) for r in results)
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from loadout.exceptions import LoadoutCommandError
-from loadout.runner import run
+from loadout.runner import brew_prefix_is_owned, run
 
 
 class TestRunNormal:
@@ -370,3 +370,56 @@ class TestRunBrewPath:
         assert call_kwargs["env"] is not None
         path_entries = call_kwargs["env"]["PATH"].split(os.pathsep)
         assert path_entries[0] == "/opt/homebrew/bin"
+
+
+class TestBrewPrefixIsOwned:
+    """Test brew_prefix_is_owned ownership check."""
+
+    def setup_method(self) -> None:
+        """Clear the brew detection cache before each test."""
+        from loadout.runner import detect_brew_bin
+
+        detect_brew_bin.cache_clear()
+
+    @patch("loadout.runner.os.path.isfile", return_value=False)
+    def test_returns_true_when_no_brew(self, _mock_exists: MagicMock) -> None:
+        """No brew detected — returns True so callers handle it separately."""
+        assert brew_prefix_is_owned() is True
+
+    @patch("loadout.runner.os.getuid", return_value=501)
+    @patch("loadout.runner.os.stat")
+    @patch(
+        "loadout.runner.os.path.isfile",
+        side_effect=_apple_silicon_brew_exists,
+    )
+    def test_returns_true_when_owned(
+        self, _mock_exists: MagicMock, mock_stat: MagicMock, _mock_uid: MagicMock
+    ) -> None:
+        """Returns True when prefix is owned by current user."""
+        mock_stat.return_value = MagicMock(st_uid=501)
+        assert brew_prefix_is_owned() is True
+
+    @patch("loadout.runner.os.getuid", return_value=501)
+    @patch("loadout.runner.os.stat")
+    @patch(
+        "loadout.runner.os.path.isfile",
+        side_effect=_apple_silicon_brew_exists,
+    )
+    def test_returns_false_when_not_owned(
+        self, _mock_exists: MagicMock, mock_stat: MagicMock, _mock_uid: MagicMock
+    ) -> None:
+        """Returns False when prefix is owned by a different user."""
+        mock_stat.return_value = MagicMock(st_uid=602)
+        assert brew_prefix_is_owned() is False
+
+    @patch("loadout.runner.os.getuid", return_value=501)
+    @patch("loadout.runner.os.stat", side_effect=OSError("Permission denied"))
+    @patch(
+        "loadout.runner.os.path.isfile",
+        side_effect=_apple_silicon_brew_exists,
+    )
+    def test_returns_false_on_stat_error(
+        self, _mock_exists: MagicMock, _mock_stat: MagicMock, _mock_uid: MagicMock
+    ) -> None:
+        """Returns False when os.stat raises OSError."""
+        assert brew_prefix_is_owned() is False

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -19,11 +19,13 @@ from loadout.update import run_update, run_upgrade
 @patch("loadout.update.install_globals")
 @patch("loadout.update.build_dotfiles")
 @patch("loadout.brew.run")
+@patch("loadout.brew.brew_prefix_is_owned", return_value=True)
 @patch("loadout.brew.shutil.which", return_value="/opt/homebrew/bin/brew")
 @patch("loadout.update.run")
 def test_run_update_full_flow(
     mock_update_run: MagicMock,
     mock_brew_which: MagicMock,
+    _mock_brew_owned: MagicMock,
     mock_brew_run: MagicMock,
     mock_build: MagicMock,
     mock_globals: MagicMock,
@@ -64,11 +66,13 @@ def test_run_update_full_flow(
 @patch("loadout.update.install_globals")
 @patch("loadout.update.build_dotfiles")
 @patch("loadout.brew.run")
+@patch("loadout.brew.brew_prefix_is_owned", return_value=True)
 @patch("loadout.brew.shutil.which", return_value="/opt/homebrew/bin/brew")
 @patch("loadout.update.run")
 def test_run_update_dry_run(
     mock_update_run: MagicMock,
     mock_brew_which: MagicMock,
+    _mock_brew_owned: MagicMock,
     mock_brew_run: MagicMock,
     mock_build: MagicMock,
     mock_globals: MagicMock,
@@ -100,11 +104,13 @@ def test_run_update_dry_run(
 @patch("loadout.update.install_globals")
 @patch("loadout.update.build_dotfiles")
 @patch("loadout.brew.run")
+@patch("loadout.brew.brew_prefix_is_owned", return_value=True)
 @patch("loadout.brew.shutil.which", return_value="/opt/homebrew/bin/brew")
 @patch("loadout.update.run")
 def test_run_update_missing_dotfiles_dir(
     mock_update_run: MagicMock,
     mock_brew_which: MagicMock,
+    _mock_brew_owned: MagicMock,
     mock_brew_run: MagicMock,
     mock_build: MagicMock,
     mock_globals: MagicMock,
@@ -160,11 +166,13 @@ def test_run_update_no_brew(
 @patch("loadout.update.install_globals")
 @patch("loadout.update.build_dotfiles")
 @patch("loadout.brew.run")
+@patch("loadout.brew.brew_prefix_is_owned", return_value=True)
 @patch("loadout.brew.shutil.which", return_value="/opt/homebrew/bin/brew")
 @patch("loadout.update.run")
 def test_run_update_no_brewfile(
     mock_update_run: MagicMock,
     mock_brew_which: MagicMock,
+    _mock_brew_owned: MagicMock,
     mock_brew_run: MagicMock,
     mock_build: MagicMock,
     mock_globals: MagicMock,
@@ -226,11 +234,13 @@ def test_run_update_skip_brew(
 @patch("loadout.update.install_globals")
 @patch("loadout.update.build_dotfiles")
 @patch("loadout.brew.run")
+@patch("loadout.brew.brew_prefix_is_owned", return_value=True)
 @patch("loadout.brew.shutil.which", return_value="/opt/homebrew/bin/brew")
 @patch("loadout.update.run")
 def test_run_update_skip_globals(
     mock_update_run: MagicMock,
     mock_brew_which: MagicMock,
+    _mock_brew_owned: MagicMock,
     mock_brew_run: MagicMock,
     mock_build: MagicMock,
     mock_globals: MagicMock,
@@ -299,13 +309,17 @@ def test_run_update_skip_both(
 @patch("loadout.update.install_globals")
 @patch("loadout.update.build_dotfiles")
 @patch("loadout.brew.run")
+@patch("loadout.brew.brew_prefix_is_owned", return_value=True)
 @patch("loadout.brew.shutil.which", return_value="/opt/homebrew/bin/brew")
+@patch("loadout.update.brew_prefix_is_owned", return_value=True)
 @patch("loadout.update.shutil.which", return_value="/opt/homebrew/bin/brew")
 @patch("loadout.update.run")
 def test_run_upgrade_calls_update_then_upgrade(
     mock_update_run: MagicMock,
     mock_update_which: MagicMock,
+    _mock_update_owned: MagicMock,
     mock_brew_which: MagicMock,
+    _mock_brew_owned: MagicMock,
     mock_brew_run: MagicMock,
     mock_build: MagicMock,
     mock_globals: MagicMock,

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -396,3 +396,51 @@ def test_run_upgrade_skip_brew(
     # Non-brew steps should still run
     mock_build.assert_called_once()
     mock_globals.assert_called_once()
+
+
+@patch("loadout.update.build_claude_config")
+@patch("loadout.update.install_globals")
+@patch("loadout.update.build_dotfiles")
+@patch("loadout.brew.run")
+@patch("loadout.brew.brew_prefix_is_owned", return_value=False)
+@patch("loadout.brew.detect_brew_bin", return_value="/opt/homebrew/bin")
+@patch("loadout.brew.shutil.which", return_value="/opt/homebrew/bin/brew")
+@patch("loadout.update.brew_prefix_is_owned", return_value=False)
+@patch("loadout.update.detect_brew_bin", return_value="/opt/homebrew/bin")
+@patch("loadout.update.shutil.which", return_value="/opt/homebrew/bin/brew")
+@patch("loadout.update.run")
+def test_run_upgrade_skips_unowned_prefix(
+    mock_update_run: MagicMock,
+    _mock_update_which: MagicMock,
+    _mock_update_detect: MagicMock,
+    _mock_update_owned: MagicMock,
+    _mock_brew_which: MagicMock,
+    _mock_brew_detect: MagicMock,
+    _mock_brew_owned: MagicMock,
+    mock_brew_run: MagicMock,
+    mock_build: MagicMock,
+    mock_globals: MagicMock,
+    mock_claude: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Brew upgrade should be skipped when prefix is owned by another user."""
+    dotfiles = tmp_path / ".dotfiles"
+    dotfiles.mkdir()
+    private = tmp_path / ".dotfiles-private"
+    private.mkdir()
+
+    config = LoadoutConfig(base_dir=tmp_path)
+    run_upgrade(config)
+
+    # No brew upgrade call
+    brew_upgrade_calls = [
+        c for c in mock_update_run.call_args_list if c.args[0] == ["brew", "upgrade"]
+    ]
+    assert len(brew_upgrade_calls) == 0
+
+    # No brew bundle calls either (brew.py also guards)
+    mock_brew_run.assert_not_called()
+
+    # Non-brew steps should still run
+    mock_build.assert_called_once()
+    mock_globals.assert_called_once()


### PR DESCRIPTION
## Summary

- Add `brew_prefix_is_owned()` check in `runner.py` that verifies the detected Homebrew prefix is owned by the current user (`os.stat().st_uid == os.getuid()`)
- Guard all brew write operations (`update`, `bundle`, `upgrade`) in `brew.py` and `update.py` — unowned prefixes are skipped with a clear warning
- Add Homebrew ownership health check to `loadout check`

## Context

When a devbox user (`dx-*`) runs `loadout update` before their own `~/.homebrew` is installed, `detect_brew_bin()` falls through to `/opt/homebrew`. Running `brew update/bundle/upgrade` as the devbox user takes ownership of `/opt/homebrew/var/homebrew/` (locks, tmp, Cellar), breaking the parent user's Homebrew installation.

Read-only PATH augmentation is unchanged so devbox users can still discover brew-installed tools.

## Test plan

- [x] All 376 tests pass
- [x] Coverage at 95.56% (above 95% threshold)
- [x] `runner.py`, `brew.py`, `update.py` at 100% coverage
- [x] ruff lint clean
- [ ] `loadout check` shows ownership status
- [ ] `sudo -u dx-cardonomics loadout update` skips brew with warning